### PR TITLE
Fix TestBench.h -> Testbench.h

### DIFF
--- a/hardware/src/main/cpp/simmain.cpp
+++ b/hardware/src/main/cpp/simmain.cpp
@@ -17,7 +17,7 @@
 #include <getopt.h>
 #include <stdint.h>
 #include <stdio.h>
-#include "TestBench.h"
+#include "Testbench.h"
 
 namespace
 {


### PR DESCRIPTION
The old include doesn't work on case-sensitive filesystems.